### PR TITLE
Added support for /agent, /catalog and /health endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ var consul = new Consul({
 });
 ```
 
+## General
+
+Basically all calls support passing an optional parameter before the callback. This parameter is useful when wanting to pass query string parameters to the calls.
+
+For example, this can be used to filter the services returned by the health endpoint.
+
+```js
+// Get all nodes having the 'myservice' service
+consul.health.service('myservice', function (err, nodes) {
+    if (err) return console.error(err.stack);
+    console.log('nodes -- %j', nodes);
+});
+
+// Get all healthy ('passing') nodes having the 'myservice' service
+consul.health.service('myservice', {passing: 1 }, function (err, nodes) {
+    if (err) return console.error(err.stack);
+    console.log('nodes -- %j', nodes);
+});
+```
+
 ## KV API
 
 Implements the [KV](http://www.consul.io/docs/agent/http.html#toc_2) endpoints.
@@ -84,7 +104,20 @@ Implements the [agent](http://www.consul.io/docs/agent/http.html#toc_3) endpoint
   - consul.agent.services(callback)
   - consul.agent.members(callback)
 
-TODO: everything else...
+Implemented but not yet covered by tests:
+
+ - consul.agent.join(address, callback)
+ - consul.agent.forceLeave(node, callback)
+ - consul.agent.registerCheck(check, callback)
+ - consul.agent.deregisterCheck(checkId, callback)
+ - consul.agent.passCheck(checkId, callback)
+ - consul.agent.warnCheck(checkId, callback)
+ - consul.agent.failCheck(checkId, callback)
+ - consul.agent.registerService(service, callback)
+ - consul.agent.deregisterService(serviceId, callback)
+
+
+TODO: Implement tests for the remaining calls.
 
 ```js
 var consul = new Consul();
@@ -109,11 +142,33 @@ consul.agent.members(function (err, members) {
 
 Implements the [catalog](http://www.consul.io/docs/agent/http.html#toc_16) endpoints.
 
-TODO: everything...
+Currently implemented:
+
+ - consul.catalog.service(serviceName, callback)
+
+TODO: Implement the remaining calls.
 
 ### Health API
 
 Implements the [health](http://www.consul.io/docs/agent/http.html#toc_24) endpoints.
 
-TODO: everything...
+ - node(node, callback)
+ - checks(serviceName, callback)
+ - service(serviceName, opts, callback)
+ - state(state, callback)
 
+The opts parameter can be used for filtering. Set it to ``{passing: 1}`` to add a query parameter to the request,
+which causes the Consul HTTP API to only return service nodes with passing checks.
+
+## Running tests
+
+To run the tests, you have to have the Consul agent running locally.
+
+Start the agent using:
+
+```
+// From the consul-node root folder
+$ consul agent -config-dir=./test/config/consul.d
+```
+
+Then execute the tests using ``npm test``.

--- a/examples/health.js
+++ b/examples/health.js
@@ -1,0 +1,15 @@
+
+var Consul = require('..');
+var consul = new Consul();
+
+// Get all nodes having the 'myservice' service
+consul.health.service('myservice', function (err, nodes) {
+    if (err) return console.error(err.stack);
+    console.log('nodes -- %j', nodes);
+});
+
+// Get all healthy ('passing') nodes having the 'myservice' service
+consul.health.service('myservice', {passing: 1 }, function (err, nodes) {
+    if (err) return console.error(err.stack);
+    console.log('nodes -- %j', nodes);
+});

--- a/lib/agent.js
+++ b/lib/agent.js
@@ -72,7 +72,7 @@ Agent.prototype.services = function (opts, done) {
        'id': services[name]['ID'],
        'service': services[name]['Service'],
        'tags': services[name]['Tags'],
-       'port': services[name]['Port'],
+       'port': services[name]['Port']
       };
     });
 
@@ -111,5 +111,122 @@ Agent.prototype.members = function (opts, done) {
       };
     }));
   });
+};
+
+/**
+ * Trigger local agent to join a node.
+ *
+ * @param {String} address
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.join = function (address, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('join/' + address, opts, done);
+};
+
+/**
+ * Force remove node.
+ *
+ * @param {String} node
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.forceLeave = function (node, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('force-leave/' + node, opts, done);
+};
+
+/**
+ * Registers a new local check.
+ *
+ * @param {Object} check
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.registerCheck = function (check, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.put('check/register', check, opts, done);
+};
+
+/**
+ * Deregister a local check.
+ *
+ * @param {String} checkId
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.deregisterCheck = function (checkId, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('check/deregister/' + checkId, opts, done);
+};
+
+/**
+ * Mark a local test as passing.
+ *
+ * @param {String} checkId
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.passCheck = function (checkId, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('check/pass/' + checkId, opts, done);
+};
+
+/**
+ * Mark a local test as warning.
+ *
+ * @param {String} checkId
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.warnCheck = function (checkId, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('check/warn/' + checkId, opts, done);
+};
+
+/**
+ * Mark a local test as critical.
+ *
+ * @param {String} checkId
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.failCheck = function (checkId, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('check/fail/' + checkId, opts, done);
+};
+
+/**
+ * Registers a new local service.
+ *
+ * @param {Object} service
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.registerService = function (service, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('service/register', service, opts, done);
+};
+
+/**
+ * Deregister a local service.
+ *
+ * @param {String} serviceId
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Agent.prototype.deregisterService = function (serviceId, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('service/deregister/' + serviceId, opts, done);
 };
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -21,3 +21,16 @@ module.exports = Catalog;
 function Catalog (consul) {
   this.requestor = new Requestor('catalog', consul);
 }
+
+/**
+ * Lists the nodes in a given service.
+ *
+ * @param {String} service
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Catalog.prototype.service = function(service, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('service/' + service, opts, done);
+};

--- a/lib/health.js
+++ b/lib/health.js
@@ -14,10 +14,63 @@ module.exports = Health;
 /**
  * Health constructor.
  *
- * @param {Consul} consol
+ * @param {Consul} consul
  * @constructor
  */
 
 function Health (consul) {
-  this.requestor = new Requestor('health', consul);
+    this.requestor = new Requestor('health', consul);
 }
+
+
+/**
+ * Returns the health info of a node.
+ *
+ * @param {String} node
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Health.prototype.node = function (node, opts, done) {
+    if ('function' == typeof opts) done = opts, opts= null;
+
+    this.requestor.get('node/' + node, opts, done);
+};
+
+/**
+ * Returns the checks of a service.
+ *
+ * @param {String} service
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Health.prototype.checks = function (service, opts, done) {
+    if ('function' == typeof opts) done = opts, opts= null;
+
+    this.requestor.get('checks/' + service, opts, done);
+};
+
+/**
+ * Lists the nodes in a given service.
+ *
+ * @param {String} service
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Health.prototype.service = function(service, opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('service/' + service, opts, done);
+};
+
+/**
+ * Returns the checks in a given state.
+ *
+ * @param {String} state
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Health.prototype.state = function (state, opts, done) {
+    if ('function' == typeof opts) done = opts, opts= null;
+
+    this.requestor.get('state/' + state, opts, done);
+};

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -1,0 +1,14 @@
+
+var Consul = require('..');
+var should = require('should');
+
+describe('consul.agent', function () {
+    var consul;
+
+    beforeEach(function () {
+        consul = new Consul();
+    });
+
+    // TODO: Implement tests for the agent endpoint
+
+});

--- a/test/catalog.test.js
+++ b/test/catalog.test.js
@@ -1,0 +1,29 @@
+
+var Consul = require('..');
+var should = require('should');
+
+describe('consul.catalog', function () {
+    var consul;
+
+    beforeEach(function () {
+        consul = new Consul();
+    });
+
+    // TODO: Extend these tests
+    describe('#service', function () {
+        it('lists the nodes in a given service', function (done) {
+            consul.catalog.service('testservice', function (err, nodes) {
+                if (err) return done(err);
+
+                nodes.should.be.instanceOf(Array);
+                nodes.length.should.equal(2);
+                nodes[0].should.have.property('Node');
+                nodes[0].should.have.property('Address');
+                nodes[0].should.have.property('ServiceID');
+                nodes[0].should.have.property('ServiceName');
+
+                return done();
+            });
+        });
+    });
+});

--- a/test/config/consul.d/node.json
+++ b/test/config/consul.d/node.json
@@ -1,0 +1,8 @@
+{
+    "datacenter": "test-dc",
+    "data_dir": "/tmp/consultest",
+    "node_name": "test-node1",
+    "server": true,
+    "bootstrap": true,
+    "bind_addr": "127.0.0.1"
+}

--- a/test/config/consul.d/testservice1_nocheck.json
+++ b/test/config/consul.d/testservice1_nocheck.json
@@ -1,0 +1,8 @@
+{
+    "service": {
+        "id": "testservice1_nocheck",
+        "name": "testservice",
+        "tags": ["node"],
+        "port": 8080
+    }
+}

--- a/test/config/consul.d/testservice2_check.json
+++ b/test/config/consul.d/testservice2_check.json
@@ -1,0 +1,11 @@
+{
+    "service": {
+        "id": "testservice2_check",
+        "name": "testservice",
+        "tags": ["node"],
+        "port": 8081,
+        "check": {
+            "ttl": "1s"
+        }
+    }
+}

--- a/test/health.test.js
+++ b/test/health.test.js
@@ -1,0 +1,96 @@
+
+var Consul = require('..');
+var should = require('should');
+
+// TODO: Extend these tests
+describe('consul.health', function () {
+    var consul;
+
+    beforeEach(function () {
+        consul = new Consul();
+    });
+
+    describe('#node', function () {
+        it('returns the health info of a node', function (done) {
+            consul.health.node('test-node1', function (err, healthInfo) {
+                if (err) return done(err);
+
+                healthInfo.should.be.instanceOf(Array);
+                healthInfo.length.should.be.greaterThan(0);
+                healthInfo[0].Node.should.equal('test-node1');
+
+                return done();
+            });
+        });
+    });
+
+    // TODO: Extend to cover passing flags
+    describe('#checks', function () {
+        it('returns the checks of a service', function (done) {
+            consul.health.checks('testservice', function (err, checks) {
+                if (err) return done(err);
+
+                checks.should.be.instanceOf(Array);
+                checks.length.should.equal(1);
+                checks[0].Node.should.equal('test-node1');
+                checks[0].ServiceID.should.equal('testservice2_check');
+
+                return done();
+            });
+        });
+    });
+
+
+    describe('#service', function () {
+        it('lists the nodes in a given service', function (done) {
+            consul.health.service('testservice', function (err, nodes) {
+                if (err) return done(err);
+
+                nodes.should.be.instanceOf(Array);
+                nodes.length.should.equal(2);
+
+                return done();
+            });
+        });
+
+        it('returns only healthy service nodes when "passing" flag is passed', function (done) {
+            consul.health.service('testservice', {passing: 1 }, function (err, nodes) {
+                if (err) return done(err);
+
+                nodes.should.be.instanceOf(Array);
+                nodes.length.should.equal(1);
+
+                return done();
+            });
+        });
+    });
+
+    // TODO: Possibly extend to contain a test for "warning" checks?
+    describe('#state', function () {
+        it('returns the checks that are passing', function (done) {
+            consul.health.state('passing', function (err, checks) {
+                if (err) return done(err);
+
+                checks.should.be.instanceOf(Array);
+                checks.length.should.equal(1);
+                checks[0].CheckID.should.equal('serfHealth');
+                checks[0].Status.should.equal('passing');
+
+                return done();
+            });
+        });
+
+        it('returns the checks that are critical', function (done) {
+            consul.health.state('critical', function (err, checks) {
+                if (err) return done(err);
+
+                checks.should.be.instanceOf(Array);
+                checks.length.should.equal(1);
+                checks[0].CheckID.should.equal('service:testservice2_check');
+                checks[0].Status.should.equal('critical');
+
+                return done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Stubs for tests for these endpoints added.
Not all methods are implemented and/or covered by tests. I've tried to update the readme to reflect what remains to be done.

Readme extended to cover the opts parameter as well as instructions on running tests and configuration files for the Consul agent used by the tests have been added.
