### PR TITLE
Better error handling in case of Consul failure

### DIFF
--- a/lib/requestor.js
+++ b/lib/requestor.js
@@ -83,9 +83,9 @@ Requestor.prototype.request = function (opts, done) {
         }
         return done(err);
       default:
-		err = new Error('Consul Error');
-		err.code = res.statusCode;
-		err.body = res.body;
+        err = new Error('Consul Error');
+        err.code = res.statusCode;
+        err.body = res.body;
         return done(err);
     }
   }.bind(this));

--- a/lib/requestor.js
+++ b/lib/requestor.js
@@ -83,7 +83,10 @@ Requestor.prototype.request = function (opts, done) {
         }
         return done(err);
       default:
-        return done(new Error('not implemented'));
+		err = new Error('Consul Error');
+		err.code = res.statusCode;
+		err.body = res.body;
+        return done(err);
     }
   }.bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Garrett Johnson",
   "license": "MIT",
   "dependencies": {
-    "debug": "^1.0.2",
+    "debug": "1.0.2",
     "defaults": "1.0.0",
     "is-type": "0.0.1",
     "request": "2.34.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Garrett Johnson",
   "license": "MIT",
   "dependencies": {
+    "debug": "^1.0.2",
     "defaults": "1.0.0",
     "is-type": "0.0.1",
     "request": "2.34.0",


### PR DESCRIPTION
I've stumbled upon a problem with the current NPM version, where I couldn't resume from a Consul failure because the error was thrown instead of called-back. It appears it's already fixed in master, but here's a suggestion, to return more information...

Here's an example:

```
{ [Error: socket hang up] code: 'ECONNRESET' }
{ [Error: Consul Error] code: 500, body: 'No cluster leader' }
```

I've also added module 'debug' as a dependency in package.json as it's required.
