### PR TITLE
Do not try to base64 decode empty values

### DIFF
--- a/lib/agent.js
+++ b/lib/agent.js
@@ -214,7 +214,7 @@ Agent.prototype.failCheck = function (checkId, opts, done) {
 Agent.prototype.registerService = function (service, opts, done) {
     if ('function' == typeof opts) done = opts, opts = null;
 
-    this.requestor.get('service/register', service, opts, done);
+    this.requestor.put('service/register', service, opts, done);
 };
 
 /**

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -14,13 +14,25 @@ module.exports = Catalog;
 /**
  * Catalog constructor.
  *
- * @param {Consul} consol
+ * @param {Consul} consul
  * @constructor
  */
 
 function Catalog (consul) {
   this.requestor = new Requestor('catalog', consul);
 }
+
+/**
+ * Lists the services in a catalog.
+ *
+ * @param {Object} [opts]
+ * @param {Function} done
+ */
+Catalog.prototype.services = function(opts, done) {
+    if ('function' == typeof opts) done = opts, opts = null;
+
+    this.requestor.get('services', opts, done);
+};
 
 /**
  * Lists the nodes in a given service.

--- a/lib/kv.js
+++ b/lib/kv.js
@@ -40,12 +40,14 @@ KV.prototype.get = function (key, opts, done) {
     if (!items) return done(null, items);
 
     done(null, items.map(function (item) {
+      // do not try to base64 decode empty items e.g. nulls
+      var val = (item['Value']) ? new Buffer(item['Value'], 'base64').toString('utf8') : item['Value'];
       return {
         createIndex: item['CreateIndex'],
         modifyIndex: item['ModifyIndex'],
         key: item['Key'],
         flags: item['Flags'],
-        value: new Buffer(item['Value'], 'base64').toString('utf8')
+        value: val 
       };
     }));
   });

--- a/lib/requestor.js
+++ b/lib/requestor.js
@@ -125,13 +125,19 @@ Requestor.prototype.get = function (path, opts, done) {
  */
 
 Requestor.prototype.put = function (path, data, opts, done) {
-  this.request({
+  var req = {
     method: 'PUT',
     url: this.urlFor(path),
     qs: opts,
-    body: data,
     encoding: 'utf8'
-  }, done);
+  };
+
+  if (data && typeof data == 'object')
+    req.json = data;
+  else
+    req.body = data;
+
+  this.request(req, done);
 };
 
 /**


### PR DESCRIPTION
It is possible for consul kv items to be empty, e.g. you might get
something like

{"CreateIndex":915,"ModifyIndex":915,"LockIndex":0,"Key":"some/key/prefix","Flags":4,"Value":null}

In this case, node-consul will attempt to base64 decode this, which
results in an exception being thrown, e.g.:

TypeError: Cannot read property 'length' of null
    at new Buffer (buffer.js:184:31)
        at
        /proj/node_modules/consul-node/lib/kv.js:49:16
        ...

This prevents that from happening.
